### PR TITLE
Purer python

### DIFF
--- a/abce/__init__.py
+++ b/abce/__init__.py
@@ -15,15 +15,14 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 # pylint: disable=W0212, C0111
-""" The best way to start creating a simulation is by copying the start.py file
-and other files from 'abce/template'.
+""" The best way to start creating a simulation is by copying the start.py
+file and other files from 'abce/template'.
 
 To see how to create a simulation read :doc:`Walk_through`. In this module you
 will find the explanation for the command.
 
 This is a minimal template for a start.py::
 
-    from __future__ import division  # makes / division work correct in python !
     from agent import Agent
     from abce import *
 
@@ -36,15 +35,6 @@ This is a minimal template for a start.py::
         agents.do('three')
     simulation.graphs()
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import zip
-from builtins import str
-from builtins import range
-from builtins import object
-from builtins import list
-import csv
 import datetime
 import os
 import time
@@ -54,20 +44,19 @@ from multiprocessing.managers import BaseManager
 import abce.db
 import abce.abcelogger
 from . import postprocess
-from glob import glob
 from .agent import Agent, Trade
 from .group import Group
 from collections import defaultdict, OrderedDict
 from abce.notenoughgoods import NotEnoughGoods
-from abce.agents import (FirmMultiTechnologies, ProductionFunction, Firm, Household,
-                         Utility_Function, SilentDeadAgent, LoudDeadAgent)
+from abce.agents import (FirmMultiTechnologies, ProductionFunction, Firm,
+                         Household, Utility_Function, SilentDeadAgent,
+                         LoudDeadAgent)
 from .quote import Quote
 from abce.contracts import Contracting
 import json
 from . import abcegui
 from .processorgroup import ProcessorGroup
 from .abcegui import gui
-import numpy as np
 
 
 def execute_advance_round_wrapper(inp):
@@ -79,11 +68,14 @@ class MyManager(BaseManager):
 
 
 class Simulation(object):
-    """ This class in which the simulation is run. Actions and agents have to be
-    added. databases and resource declarations can be added. Then runs
+    """ This class in which the simulation is run. Actions and agents have to
+    be added. databases and resource declarations can be added. Then runs
     the simulation.
 
     Args:
+        name:
+            name of the simulation
+
         random_seed (optional):
             a random seed that controls the random number of the simulation
 
@@ -92,20 +84,23 @@ class Simulation(object):
             'group' (fast) or 'individual' (slow) or 'off'
 
         processes (optional):
-            The number of processes that run in parallel. Each process hosts a share of
-            the agents.
-            Default is all your logical processor cores times two, using hyper-threading when available.
-            For easy debugging set processes to one and the simulation is executed
-            without parallelization.
-            Sometimes it is advisable to decrease the number of processes to the number
-            of logical or even physical processor cores on your computer.
-            'None' for all processor cores times 2.
-            **For easy debugging set processes to 1, this way only one agent runs at
-            a time and only one error message is displayed**
+            The number of processes that run in parallel. Each process hosts
+            a share of the agents.
+            Default is all your logical processor cores times two, using
+            hyper-threading when available.
+            For easy debugging set processes to one and the simulation is
+            executed without parallelization.
+            Sometimes it is advisable to decrease the number of processes to
+            the number of logical or even physical processor cores on your
+            computer. 'None' for all processor cores times 2.
+            **For easy debugging set processes to 1, this way only one agent
+            runs at a time and only one error message is displayed**
 
         Example::
 
-            simulation = Simulation(name='ABCE', trade_logging='individual', processes=None)
+            simulation = Simulation(name='ABCE',
+                                    trade_logging='individual',
+                                    processes=None)
 
 
     Example for a simulation::
@@ -113,10 +108,13 @@ class Simulation(object):
         num_firms = 5
         num_households = 200000
 
-        w = Simulation(name='ABCE', trade_logging='individual', processes=None)
+        w = Simulation(name='ABCE',
+                       trade_logging='individual',
+                       processes=None)
 
-        w.declare_round_endowment(resource='labor_endowment', productivity=1, product='labor')
-        w.declare_round_endowment(resource='capital_endowment', productivity=1, product='capital')
+        w.declare_round_endowment(resource='labor_endowment',
+                                  productivity=1,
+                                  product='labor')
 
         w.panel_data('firm', command='after_sales_before_consumption')
 
@@ -124,21 +122,24 @@ class Simulation(object):
         households = w.build_agents(Household, 'household', num_households)
 
         all = firms + households
-        for round in w.next_round():
-            households.do('recieve_connections'),
-            households.do('offer_capital'),
-            firms.do('buy_capital'),
-            firms.do('production'),
-            if round = 250:
-                centralbank.do('intervention)
-            households.do(buy_product')
-            all.do('after_sales_before_consumption')
-            households.do('consume')
+        for round in range(round):
+            self.advance_round(round)
+            households.recieve_connections()
+            households.offer_capital()
+            firms.buy_capital()
+            firms.production()
+            if round == 250:
+                centralbank.intervention()
+            households.buy_product()
+            all.after_sales_before_consumption()
+            households.consume()
 
+        w.finalize()
         w.graphs()
     """
 
-    def __init__(self, name='abce', random_seed=None, trade_logging='off', processes=None):
+    def __init__(self, name='abce', random_seed=None,
+                 trade_logging='off', processes=1):
         """
         """
         self.num_of_agents_in_group = {}
@@ -166,8 +167,9 @@ class Simulation(object):
 
         self.path = (os.path.abspath('.') + '/result/' + name + '_' +
                      datetime.datetime.now().strftime("%Y-%m-%d_%H-%M"))
-        """ the path variable contains the path to the simulation outcomes it can be used
-        to generate your own graphs as all resulting csv files are there.
+        """ the path variable contains the path to the simulation outcomes
+        it can be used to generate your own graphs as all resulting
+        csv files are there.
         """
         while True:
             try:
@@ -185,7 +187,10 @@ class Simulation(object):
         manager = mp.Manager()
         self.database_queue = manager.Queue()
         self._db = abce.db.Database(
-            self.path, self.database_queue, trade_log=self.trade_logging_mode != 'off')
+            self.path,
+            self.database_queue,
+            trade_log=self.trade_logging_mode != 'off')
+        self.db_started = False
         self.logger_queue = manager.Queue()
 
         self.processes = mp.cpu_count() * 2 if processes is None else processes
@@ -218,37 +223,44 @@ class Simulation(object):
         self.clock = time.time()
         self.database = self
 
-    def declare_round_endowment(self, resource, units, product, groups=['all']):
-        """ At the beginning of very round the agent gets 'units' units of good 'product' for
-        every 'resource' he possesses.
+    def declare_round_endowment(self, resource, units,
+                                product, groups):
+        """ At the beginning of very round the agent gets 'units' units
+        of good 'product' for every 'resource' he possesses.
 
-        Round endowments can be group specific, that means that when somebody except
-        this group holds them they do not produce. The default is 'all'.
+        Round endowments are group specific, that means that when
+        somebody except the specified group holds them they do not produce.
 
         Args::
 
             resource:
                 The good that you have to hold to get the other
+
             units:
                 the multiplier to get the produced good
+
             product:
                 the good that is produced if you hold the first good
+
             groups:
-                a list of agent groups, which gain the second good, if they hold the first one
+                a list of agent groups, which gain the second good,
+                if they hold the first one
 
         Example::
 
             A farmer gets a ton of harvest for every acre:
 
-            w.declare_round_endowment(resource='land', units=1000, product='wheat')
-
-
+            w.declare_round_endowment(resource='land',
+                                      units=1000,
+                                      product='wheat')
         """
         if self.num_of_agents_in_group:
             raise Exception(
-                "WARNING: declare_round_endowment(...) must be called before the agents are build")
+                "WARNING: declare_round_endowment(...)"
+                " must be called before the agents are build")
         for group in groups:
-            self.resource_endowment[group].append((resource, units, product))
+            self.resource_endowment[group].append(
+                (resource, units, product))
 
     def declare_perishable(self, good):
         """ This good only lasts one round and then disappears. For example
@@ -272,7 +284,8 @@ class Simulation(object):
         """
         if self.num_of_agents_in_group:
             raise Exception(
-                "WARNING: declare_perishable(...) must be called before the agents are build")
+                "WARNING: declare_perishable(...) must be called before "
+                "the agents are build")
         self.perishable.append(good)
 
     def declare_expiring(self, good, duration):
@@ -289,17 +302,21 @@ class Simulation(object):
         """
         if self.num_of_agents_in_group:
             raise Exception(
-                "WARNING: declare_expiring(...) must be called before the agents are build")
+                "WARNING: declare_expiring(...) must be called "
+                "before the agents are build")
         self.expiring.append((good, duration))
 
-    def declare_service(self, human_or_other_resource, units, service, groups=['all']):
-        """ When the agent holds the human_or_other_resource, he gets 'units' of service every round
-            the service can be used only with in this round.
+    def declare_service(self, human_or_other_resource,
+                        units, service, groups=['all']):
+        """ When the agent holds the human_or_other_resource,
+        he gets 'units' of service every round
+        the service can be used only with in this round.
 
         Args::
 
             human_or_other_resource:
-                the good that needs to be in possessions to create the other good 'self.create('adult', 2)'
+                the good that needs to be in possessions to create the other
+                good 'self.create('adult', 2)'
             units:
                 how many units of the service is available
             service:
@@ -309,7 +326,8 @@ class Simulation(object):
 
         Example::
 
-            For example if a household has two adult family members, it gets 16 hours of work
+            For example if a household has two adult family members, it gets
+            16 hours of work
 
             w.declare_service('adult', 8, 'work')
         """
@@ -320,9 +338,9 @@ class Simulation(object):
     def panel(self, group, possessions=[], variables=[]):
         """ panel(.) writes a panel of variables and possessions
             of a group of agents into the database, so that it is displayed
-            in the gui. Aggregate must be declared before the agents are build.
-            ('agent_group', 'panel') must be in the action_list, so that
-            the simulation knows when to make the aggregate snapshot.
+            in the gui. Aggregate must be declared before the agents are
+            build. ('agent_group', 'panel') must be in the action_list, so
+            that the simulation knows when to make the aggregate snapshot.
 
             Args:
                 group:
@@ -339,7 +357,7 @@ class Simulation(object):
             ...
 
             simulation.panel('firm', possessions=['money', 'input'],
-                                     variables=['production_target', 'gross_revenue'])
+                             variables=['production_target', 'gross_revenue'])
 
             for round in simulation.next_round():
                 firms.do('produce_and_sell)
@@ -348,17 +366,18 @@ class Simulation(object):
         """
         if self.num_of_agents_in_group:
             raise Exception(
-                "WARNING: panel(...) must be called before the agents are build")
+                "WARNING: panel(...) must be called before the agents are "
+                "build")
         self._db.add_panel(group, possessions + variables)
         self.variables_to_track_panel[group] = variables
         self.possessins_to_track_panel[group] = possessions
 
     def aggregate(self, group, possessions=[], variables=[]):
-        """ aggregate(.) writes summary statistics of variables and possessions
-            of a group of agents into the database, so that it is displayed in
-            the gui. Aggregate must be declared before the agents are build.
-            ('agent_group', 'aggregate') must be in the action_list, so that
-            the simulation knows when to make the aggregate snapshot.
+        """ aggregate(.) writes summary statistics of variables and
+        possessions of a group of agents into the database, so that it is
+        displayed in the gui. Aggregate must be declared before the agents
+        are build. ('agent_group', 'aggregate') must be in the action_list,
+        so that the simulation knows when to make the aggregate snapshot.
 
 
             Args:
@@ -377,7 +396,8 @@ class Simulation(object):
             ...
 
             simulation.aggregate('firm', possessions=['money', 'input'],
-                                     variables=['production_target', 'gross_revenue'])
+                                 variables=['production_target',
+                                            'gross_revenue'])
 
             for round in simulation.next_round():
                 firms.do('produce_and_sell)
@@ -389,7 +409,8 @@ class Simulation(object):
         """
         if self.num_of_agents_in_group:
             raise Exception(
-                "WARNING: aggregate(...) must be called before the agents are build")
+                "WARNING: aggregate(...) must be called before the agents "
+                "are build")
         self._db.add_aggregate(group, possessions + variables)
         self.variables_to_track_aggregate[group] = variables
         self.possessions_to_track_aggregate[group] = possessions
@@ -435,41 +456,51 @@ class Simulation(object):
         parameters = ((pg, time) for pg in self._processor_groups)
         self.pool.map(execute_advance_round_wrapper, parameters, chunksize=1)
 
-    def advance_time(self, time):
+    def advance_round(self, time):
+        if not self.db_started:
+            self._db.start()
+            self.db_started = True
         print("\rRound" + str(time))
         self.execute_advance_round(time)
         self.add_and_delete_agents(time)
 
-    def gracefull_exit(self):
-        print('')
-        print(str("time only simulation %6.2f" % (time.time() - self.clock)))
-        self.database_queue.put('close')
-        self.logger_queue.put(['close', 'close', 'close'])
+    def __del__(self):
+        self.finalize()
 
-        try:
-            while self._logger.is_alive():
+    def finalize(self):
+        if self.db_started:
+            self.db_started = False
+            print('')
+            print(str("time only simulation %6.2f" %
+                  (time.time() - self.clock)))
+            self.database_queue.put('close')
+            self.logger_queue.put(['close', 'close', 'close'])
+
+            try:
+                while self._logger.is_alive():
+                    time.sleep(0.05)
+            except AttributeError:
+                pass
+
+            while self._db.is_alive():
                 time.sleep(0.05)
-        except AttributeError:
-            pass
 
-        while self._db.is_alive():
-            time.sleep(0.05)
+            try:
+                self.pool.close()
+                self.pool.join()
+            except AttributeError:
+                pass
 
-        try:
-            self.pool.close()
-            self.pool.join()
-        except AttributeError:
-            pass
+            print(str("time with data and network %6.2f" %
+                      (time.time() - self.clock)))
+            self._write_description_file()
+            self._displaydescribtion()
+            postprocess.to_csv(os.path.abspath(self.path))
+            print(str("time with post processing %6.2f" %
+                      (time.time() - self.clock)))
 
-        print(str("time with data and network %6.2f" %
-                  (time.time() - self.clock)))
-        self._write_description_file()
-        self._displaydescribtion()
-        postprocess.to_csv(os.path.abspath(self.path))
-        print(str("time with post processing %6.2f" %
-                  (time.time() - self.clock)))
-
-    def build_agents(self, AgentClass, group_name, number=None, parameters={}, agent_parameters=None):
+    def build_agents(self, AgentClass, group_name, number=None,
+                     parameters={}, agent_parameters=None):
         """ This method creates agents.
 
         Args:
@@ -478,8 +509,9 @@ class Simulation(object):
                 is the name of the AgentClass that you imported
 
             group_name:
-                the name of the group, as it will be used in the action list and transactions.
-                Should generally be lowercase of the AgentClass.
+                the name of the group, as it will be used in the action list
+                and transactions. Should generally be lowercase of the
+                AgentClass.
 
             number:
                 number of agents to be created.
@@ -497,11 +529,19 @@ class Simulation(object):
 
         Example::
 
-         firms = simulation.build_agents(Firm, 'firm', number=simulation_parameters['num_firms'])
-         banks = simulation.build_agents(Bank, 'bank', parameters=simulation_parameters, agent_parameters=[{'name': UBS'},{'name': 'amex'},{'name': 'chase'})
-         centralbanks = simulation.build_agents(CentralBank, 'centralbank', number=1, parameters={'rounds': num_rounds})
+         firms = simulation.build_agents(Firm, 'firm',
+             number=simulation_parameters['num_firms'])
+         banks = simulation.build_agents(Bank, 'bank',
+                                         parameters=simulation_parameters,
+                                         agent_parameters=[{'name': UBS'},
+                                         {'name': 'amex'},{'name': 'chase'})
+         centralbanks = simulation.build_agents(CentralBank, 'centralbank',
+                                                number=1,
+                                                parameters={'rounds':
+                                                             num_rounds})
         """
-        assert number is None or agent_parameters is None, 'either set number or agent_parameters in build_agents'
+        assert number is None or agent_parameters is None, \
+            'either set number or agent_parameters in build_agents'
         if number is not None:
             num_agents_this_group = number
             agent_parameters = [None] * num_agents_this_group
@@ -510,14 +550,16 @@ class Simulation(object):
 
         self.sim_parameters.update(parameters)
 
-        agent_params_from_sim = {'expiring': self.expiring,
-                                 'perishable': self.perishable,
-                                 'resource_endowment': self.resource_endowment[group_name] + self.resource_endowment['all'],
-                                 'panel': (self.possessins_to_track_panel[group_name],
-                                           self.variables_to_track_panel[group_name]),
-                                 'aggregate': (self.possessions_to_track_aggregate[group_name],
-                                               self.variables_to_track_aggregate[group_name]),
-                                 'ndf': self._network_drawing_frequency}
+        agent_params_from_sim = {
+            'expiring': self.expiring,
+            'perishable': self.perishable,
+            'resource_endowment': (self.resource_endowment[group_name] +
+                                   self.resource_endowment['all']),
+            'panel': (self.possessins_to_track_panel[group_name],
+                      self.variables_to_track_panel[group_name]),
+            'aggregate': (self.possessions_to_track_aggregate[group_name],
+                          self.variables_to_track_aggregate[group_name]),
+            'ndf': self._network_drawing_frequency}
 
         for pg in self._processor_groups:
             pg.add_group(AgentClass,
@@ -537,18 +579,21 @@ class Simulation(object):
     def add_and_delete_agents(self, round):
         for command, agent_details in self.messagess[-1]:
             if command == 'add':
-                AgentClass, group_name, parameters, agent_parameters = agent_details
+                (AgentClass, group_name,
+                 parameters, agent_parameters) = agent_details
                 id = self.num_of_agents_in_group[group_name]
                 self.num_of_agents_in_group[group_name] += 1
                 pg = self._processor_groups[id % self.processes]
                 pg.append(AgentClass, id=id,
                           agent_args={'group': group_name,
-                                      'trade_logging': self.trade_logging_mode,
+                                      'trade_logging':
+                                      self.trade_logging_mode,
                                       'database': self.database_queue,
                                       'logger': self.logger_queue,
                                       'random_seed': random.random(),
                                       'start_round': round + 1},
-                          parameters=parameters, agent_parameters=agent_parameters)
+                          parameters=parameters,
+                          agent_parameters=agent_parameters)
             elif command == 'delete':
                 group, id, quite = agent_details
                 pg = self._processor_groups[id % self.processes]
@@ -561,8 +606,10 @@ class Simulation(object):
     def _write_description_file(self):
         description = open(os.path.abspath(
             self.path + '/description.txt'), 'w')
-        description.write(json.dumps(self.sim_parameters, indent=4,
-                                     skipkeys=True, default=lambda x: 'not_serializeable'))
+        description.write(json.dumps(self.sim_parameters,
+                                     indent=4,
+                                     skipkeys=True,
+                                     default=lambda x: 'not_serializeable'))
 
     def _displaydescribtion(self):
         description = open(self.path + '/description.txt', 'r')
@@ -592,14 +639,9 @@ class Simulation(object):
 
             simulation.graphs()
         """
-        if self.round > 0:
-            abcegui.run(open=open, new=new)
-
-    def __enter__(self):
-        self._db.start()
-
-    def __exit__(self, a, b, trackback):
-        self.gracefull_exit()
+        if self.db_started:
+            self.finalize()
+        abcegui.run(open=open, new=new)
 
 
 def _number_or_string(word):

--- a/abce/__init__.py
+++ b/abce/__init__.py
@@ -190,7 +190,7 @@ class Simulation(object):
             self.path,
             self.database_queue,
             trade_log=self.trade_logging_mode != 'off')
-        self.db_started = False
+        self._db_started = False
         self.logger_queue = manager.Queue()
 
         self.processes = mp.cpu_count() * 2 if processes is None else processes
@@ -457,9 +457,9 @@ class Simulation(object):
         self.pool.map(execute_advance_round_wrapper, parameters, chunksize=1)
 
     def advance_round(self, time):
-        if not self.db_started:
+        if not self._db_started:
             self._db.start()
-            self.db_started = True
+            self._db_started = True
         print("\rRound" + str(time))
         self.execute_advance_round(time)
         self.add_and_delete_agents(time)
@@ -468,8 +468,8 @@ class Simulation(object):
         self.finalize()
 
     def finalize(self):
-        if self.db_started:
-            self.db_started = False
+        if self._db_started:
+            self._db_started = False
             print('')
             print(str("time only simulation %6.2f" %
                   (time.time() - self.clock)))
@@ -639,7 +639,7 @@ class Simulation(object):
 
             simulation.graphs()
         """
-        if self.db_started:
+        if self._db_started:
             self.finalize()
         abcegui.run(open=open, new=new)
 

--- a/abce/__init__.py
+++ b/abce/__init__.py
@@ -216,6 +216,7 @@ class Simulation(object):
         self.sim_parameters = OrderedDict(
             {'name': name, 'random_seed': random_seed})
         self.clock = time.time()
+        self.database = self
 
     def declare_round_endowment(self, resource, units, product, groups=['all']):
         """ At the beginning of very round the agent gets 'units' units of good 'product' for
@@ -434,7 +435,7 @@ class Simulation(object):
         parameters = ((pg, time) for pg in self._processor_groups)
         self.pool.map(execute_advance_round_wrapper, parameters, chunksize=1)
 
-    def time(self, time):
+    def advance_time(self, time):
         print("\rRound" + str(time))
         self.execute_advance_round(time)
         self.add_and_delete_agents(time)
@@ -596,7 +597,6 @@ class Simulation(object):
 
     def __enter__(self):
         self._db.start()
-        return self
 
     def __exit__(self, a, b, trackback):
         self.gracefull_exit()

--- a/abce/__init__.py
+++ b/abce/__init__.py
@@ -55,7 +55,7 @@ import abce.db
 import abce.abcelogger
 from . import postprocess
 from glob import glob
-from .agent import Agent
+from .agent import Agent, Trade
 from .group import Group
 from collections import defaultdict, OrderedDict
 from abce.notenoughgoods import NotEnoughGoods

--- a/abce/__init__.py
+++ b/abce/__init__.py
@@ -434,13 +434,6 @@ class Simulation(object):
         parameters = ((pg, time) for pg in self._processor_groups)
         self.pool.map(execute_advance_round_wrapper, parameters, chunksize=1)
 
-    def _prepare(self):
-        """ This runs the simulation """
-        if not(self.num_of_agents_in_group):
-            raise Exception('No Agents Created')
-
-        self._db.start()
-
     def time(self, time):
         print("\rRound" + str(time))
         self.execute_advance_round(time)
@@ -600,6 +593,13 @@ class Simulation(object):
         """
         if self.round > 0:
             abcegui.run(open=open, new=new)
+
+    def __enter__(self):
+        self._db.start()
+        return self
+
+    def __exit__(self, a, b, trackback):
+        self.gracefull_exit()
 
 
 def _number_or_string(word):

--- a/abce/agent.py
+++ b/abce/agent.py
@@ -72,8 +72,7 @@ class Agent(Database, NetworkLogger, Trade, Messaging):
 
     """
 
-    def __init__(self, id, group, trade_logging, database, logger, random_seed,
-                 start_round, num_managers):
+    def __init__(self, id, group, trade_logging, database, logger, random_seed, num_managers):
         """ Do not overwrite __init__ instead use a method called init instead.
         init is called whenever the agent are build.
         """
@@ -113,8 +112,10 @@ class Agent(Database, NetworkLogger, Trade, Messaging):
         self._data_to_observe = {}
         self._data_to_log_1 = {}
         self._quotes = {}
-        self.round = start_round
-        """ self.round returns the current round in the simulation READ ONLY!"""
+        self.round = None
+        """ self.round is depreciated"""
+        self.time = None
+        """ self.time, contains the time set with simulation.time(time) """
         self._resources = []
         self.variables_to_track_panel = []
         self.variables_to_track_aggregate = []
@@ -186,7 +187,7 @@ class Agent(Database, NetworkLogger, Trade, Messaging):
         self._offer_count += 1
         return hash((self.name, self._offer_count))
 
-    def _advance_round(self):
+    def _advance_round(self, time):
         for offer in list(self.given_offers.values()):
             if offer.made < self.round:
                 print("in agent %s this offers have not been retrieved:" %
@@ -219,7 +220,11 @@ class Agent(Database, NetworkLogger, Trade, Messaging):
                             'not been retrieved in this round get_messages(.)' %
                             (self.group, self.id))
 
-        self.round += 1
+        for ingredient, units, product in self._resources:
+            self._haves.create(product, self.possession(ingredient) * units)
+
+        self.round = time
+        self.time = time
 
     def create(self, good, quantity):
         """ creates quantity of the good out of nothing
@@ -301,10 +306,6 @@ class Agent(Database, NetworkLogger, Trade, Messaging):
 
     def _register_resource(self, resource, units, product):
         self._resources.append((resource, units, product))
-
-    def _produce_resource(self):
-        for ingredient, units, product in self._resources:
-            self._haves.create(product, self.possession(ingredient) * units)
 
     def _register_perish(self, good):
         self._haves._perishable.append(good)

--- a/abce/db.py
+++ b/abce/db.py
@@ -125,8 +125,13 @@ class Database(multiprocessing.Process):
             elif msg[0] == 'log':
                 group_name = msg[1]
                 data_to_write = msg[2]
-                data_to_write = {key: float(
-                    data_to_write[key]) for key in data_to_write}
+                try:
+                    data_to_write = {key: float(
+                        data_to_write[key]) for key in data_to_write}
+                except TypeError:
+                    print(data_to_write)
+                    raise
+
                 data_to_write['round'] = msg[3]
                 table_name = 'log_' + group_name
                 try:

--- a/abce/postprocess.py
+++ b/abce/postprocess.py
@@ -46,7 +46,7 @@ def to_csv(directory):
                 std = grouped.std()
                 std.rename(
                     columns={col: col + '_std' for col in std.columns}, inplace=True)
-            except:
+            except pd.core.groupby.DataError:
                 std = pd.DataFrame()
 
             result = pd.concat([aggregated, meaned, std], axis=1)

--- a/abce/postprocess.py
+++ b/abce/postprocess.py
@@ -6,7 +6,7 @@ import pandas as pd
 import datetime
 
 
-def to_csv(directory, calendar):
+def to_csv(directory):
     os.chdir(directory)
     db = sqlite3.connect('database.db')
     cursor = db.cursor()
@@ -27,11 +27,6 @@ def to_csv(directory, calendar):
             print()
             print("If you keep having problems email davoudtaghawinejad@gmail.com")
             raise
-        if calendar:
-            table['date'] = 0
-            for i in range(len(table)):
-                table.set_value(i, 'date', datetime.date.fromordinal(
-                    int(table['round'][i])))
         if 'round' in table.columns:
             table.to_csv(table_name + '.csv', index_label='index')
         else:
@@ -55,11 +50,6 @@ def to_csv(directory, calendar):
                 std = pd.DataFrame()
 
             result = pd.concat([aggregated, meaned, std], axis=1)
-            if calendar:
-                result['date'] = 0
-                for ord_date in result.index:
-                    result.set_value(ord_date, 'date',
-                                     datetime.date.fromordinal(ord_date))
             result.to_csv('aggregate_' + table_name + '.csv',
                           index_label='round', date_format='%Y-%m-%d')
 

--- a/abce/processorgroup.py
+++ b/abce/processorgroup.py
@@ -90,11 +90,11 @@ class ProcessorGroup(object):
     def name(self):
         return (self.group, self.batch)
 
-    def execute_internal(self, command):
+    def execute_advance_round(self, time):
         for group in self.agents.values():
             for agent in group:
                 try:
-                    getattr(agent, command)()
+                    agent._advance_round(time)
                 except KeyboardInterrupt:
                     return None
                 except:

--- a/unittest/start_core_engine.py
+++ b/unittest/start_core_engine.py
@@ -27,8 +27,9 @@ from victim import Victim
 def main(processes, rounds):
     s = Simulation(processes=processes, name='unittest')
     s.declare_round_endowment(
-        resource='labor_endowment', units=5, product='labor')
-    s.declare_round_endowment(resource='cow', units=10, product='milk')
+        resource='labor_endowment', units=5, product='labor', groups=['all'])
+    s.declare_round_endowment(resource='cow', units=10,
+                              product='milk', groups=['all'])
     s.declare_perishable(good='labor')
     s.panel('buy', variables=['price'])
     # s.declare_expiring('xcapital', 5)
@@ -42,32 +43,39 @@ def main(processes, rounds):
                           'rounds': rounds})  # tests give and messaging
     print('build Endowment')
     endowment = s.build_agents(Endowment, 'endowment', 2, parameters={
-                               'rounds': rounds, 'creation': 0})  # tests declare_round_endowment and declare_perishable
+                               'rounds': rounds, 'creation': 0})
+    # tests declare_round_endowment and declare_perishable
     print('build LoggerTest')
     loggertest = s.build_agents(
         LoggerTest, 'loggertest', 1, parameters={'rounds': rounds})
     print('build ProductionMultifirm')
     productionmultifirm = s.build_agents(
-        ProductionMultifirm, 'productionmultifirm', 1, parameters={'rounds': rounds})
+        ProductionMultifirm, 'productionmultifirm', 1,
+        parameters={'rounds': rounds})
     print('build ProductionFirm')
     productionfirm = s.build_agents(
         ProductionFirm, 'productionfirm', 7, parameters={'rounds': rounds})
     print('build UtilityHousehold')
     utilityhousehold = s.build_agents(
-        UtilityHousehold, 'utilityhousehold', 5, parameters={'rounds': rounds})
+        UtilityHousehold, 'utilityhousehold', 5,
+        parameters={'rounds': rounds})
     # print('build ContractSeller')
-    # contractseller = s.build_agents(ContractSeller, 'contractseller', 2, parameters={'rounds': rounds})
+    # contractseller = s.build_agents(ContractSeller, 'contractseller', 2,
+    #    parameters={'rounds': rounds})
     # print('build ContractBuyer')
-    # contractbuyer = s.build_agents(ContractBuyer, 'contractbuyer', 2, parameters={'rounds': rounds})
+    # contractbuyer = s.build_agents(ContractBuyer, 'contractbuyer', 2,
+    #    parameters={'rounds': rounds})
     # print('build ContractSellerStop')
-    # contractsellerstop = s.build_agents(ContractSellerStop, 'contractsellerstop', 2, parameters={'rounds': rounds})
+    # contractsellerstop = s.build_agents(ContractSellerStop,
+    #    'contractsellerstop', 2, parameters={'rounds': rounds})
     # print('build ContractBuyerStop')
-    # contractbuyerstop = s.build_agents(ContractBuyerStop, 'contractbuyerstop', 2, parameters={'rounds': rounds})
+    # contractbuyerstop = s.build_agents(ContractBuyerStop,
+    #    'contractbuyerstop', 2, parameters={'rounds': rounds})
     # s.build_agents(ExpiringCapital, 1)
     # s.build_agents(GiveExpiringCapital, 2)
     print('build BuyExpiringCapital')
-    _ = s.build_agents(
-        BuyExpiringCapital, 'buyexpiringcapital', 2, parameters={'rounds': rounds})
+    _ = s.build_agents(BuyExpiringCapital, 'buyexpiringcapital', 2,
+                       parameters={'rounds': rounds})
     print('build MessageA')
     messagea = s.build_agents(MessageA, 'messagea',
                               20, parameters={'rounds': rounds})
@@ -75,7 +83,8 @@ def main(processes, rounds):
     messageb = s.build_agents(MessageB, 'messageb',
                               20, parameters={'rounds': rounds})
     print('build Killer')
-    killer = s.build_agents(Killer, 'killer', 1, parameters={'rounds': rounds})
+    killer = s.build_agents(Killer, 'killer', 1,
+                            parameters={'rounds': rounds})
     print('build Victim')
     victim = s.build_agents(Victim, 'victim', rounds,
                             parameters={'rounds': rounds})
@@ -90,52 +99,52 @@ def main(processes, rounds):
 
     print('build AddAgent')
     addagent = s.build_agents(AddAgent, 'addagent', 0)
-    with s.database:
-        for r in range(rounds):
-            s.advance_time(r)
-            for _ in range(5):
-                buy.do('one')
-                buy.do('two')
-                buy.do('three')
-                buy.do('clean_up')
-            buy.do('panel')
-            for _ in range(5):
-                sell.do('one')
-                sell.do('two')
-                sell.do('three')
-                sell.do('clean_up')
-            for _ in range(5):
-                give.do('one')
-                give.do('two')
-                give.do('three')
-                give.do('clean_up')
-            for _ in range(5):
-                loggertest.do('one')
-                loggertest.do('two')
-                loggertest.do('three')
-                loggertest.do('clean_up')
-            for _ in range(5):
-                utilityhousehold.do('one')
-                utilityhousehold.do('two')
-                utilityhousehold.do('three')
-                utilityhousehold.do('clean_up')
-            endowment.do('Iconsume')
-            productionmultifirm.do('production')
-            productionfirm.do('production')
-            utilityhousehold.do('consumption')
-            (messagea + messageb).do('sendmsg')
-            (messageb + messagea).do('recvmsg')
-            # (contractbuyer + contractbuyerstop).do('request_offer')
-            # (contractseller + contractsellerstop).do('make_offer')
-            # contractagents.do('accept_offer')
-            # contractagents.do('deliver')
-            # contractagents.do('pay')
-            # contractagents.do('control')
-            killer.do('kill')
-            killer.do('send_message')
-            victim.do('am_I_dead')
-            some.do('all_tests_completed')
-            addagent.do('add_agent')
+    for r in range(rounds):
+        s.advance_round(r)
+        for _ in range(5):
+            buy.do('one')
+            buy.do('two')
+            buy.do('three')
+            buy.do('clean_up')
+        buy.do('panel')
+        for _ in range(5):
+            sell.do('one')
+            sell.do('two')
+            sell.do('three')
+            sell.do('clean_up')
+        for _ in range(5):
+            give.do('one')
+            give.do('two')
+            give.do('three')
+            give.do('clean_up')
+        for _ in range(5):
+            loggertest.do('one')
+            loggertest.do('two')
+            loggertest.do('three')
+            loggertest.do('clean_up')
+        for _ in range(5):
+            utilityhousehold.do('one')
+            utilityhousehold.do('two')
+            utilityhousehold.do('three')
+            utilityhousehold.do('clean_up')
+        endowment.do('Iconsume')
+        productionmultifirm.do('production')
+        productionfirm.do('production')
+        utilityhousehold.do('consumption')
+        (messagea + messageb).do('sendmsg')
+        (messageb + messagea).do('recvmsg')
+        # (contractbuyer + contractbuyerstop).do('request_offer')
+        # (contractseller + contractsellerstop).do('make_offer')
+        # contractagents.do('accept_offer')
+        # contractagents.do('deliver')
+        # contractagents.do('pay')
+        # contractagents.do('control')
+        killer.do('kill')
+        killer.do('send_message')
+        victim.do('am_I_dead')
+        some.do('all_tests_completed')
+        addagent.do('add_agent')
+    s.finalize()
 
 
 if __name__ == '__main__':

--- a/unittest/start_core_engine.py
+++ b/unittest/start_core_engine.py
@@ -25,7 +25,7 @@ from victim import Victim
 
 
 def main(processes, rounds):
-    s = Simulation(rounds=rounds, processes=processes, name='unittest')
+    s = Simulation(processes=processes, name='unittest')
 
     s.declare_round_endowment(
         resource='labor_endowment', units=5, product='labor')
@@ -67,7 +67,7 @@ def main(processes, rounds):
     # s.build_agents(ExpiringCapital, 1)
     # s.build_agents(GiveExpiringCapital, 2)
     print('build BuyExpiringCapital')
-    buyexpiringcapital = s.build_agents(
+    _ = s.build_agents(
         BuyExpiringCapital, 'buyexpiringcapital', 2, parameters={'rounds': rounds})
     print('build MessageA')
     messagea = s.build_agents(MessageA, 'messagea',
@@ -75,16 +75,13 @@ def main(processes, rounds):
     print('build MessageB')
     messageb = s.build_agents(MessageB, 'messageb',
                               20, parameters={'rounds': rounds})
-    print('build AddAgent')
-    messagec = s.build_agents(AddAgent, 'addagent', 1,
-                              parameters={'rounds': rounds})
     print('build Killer')
     killer = s.build_agents(Killer, 'killer', 1, parameters={'rounds': rounds})
     print('build Victim')
     victim = s.build_agents(Victim, 'victim', rounds,
                             parameters={'rounds': rounds})
     print('build Victim loudvictim')
-    loudvictim = s.build_agents(
+    _ = s.build_agents(
         Victim, 'loudvictim', rounds, parameters={'rounds': rounds})
 
     some = buy + sell + give + loggertest + utilityhousehold
@@ -92,8 +89,11 @@ def main(processes, rounds):
 #    contractagents = (contractbuyer + contractseller
 #                      + contractbuyerstop + contractsellerstop)
 
+    print('build AddAgent')
     addagent = s.build_agents(AddAgent, 'addagent', 0)
-    for round in s.next_round():
+    s._prepare()
+    for r in range(rounds):
+        s.time(r)
         for _ in range(5):
             buy.do('one')
             buy.do('two')
@@ -135,11 +135,9 @@ def main(processes, rounds):
         killer.do('kill')
         killer.do('send_message')
         victim.do('am_I_dead')
-
-        # ('expiringcapital', 'go'),
-
         some.do('all_tests_completed')
         addagent.do('add_agent')
+    s.gracefull_exit()
 
 
 if __name__ == '__main__':

--- a/unittest/start_core_engine.py
+++ b/unittest/start_core_engine.py
@@ -26,7 +26,6 @@ from victim import Victim
 
 def main(processes, rounds):
     s = Simulation(processes=processes, name='unittest')
-
     s.declare_round_endowment(
         resource='labor_endowment', units=5, product='labor')
     s.declare_round_endowment(resource='cow', units=10, product='milk')
@@ -91,53 +90,52 @@ def main(processes, rounds):
 
     print('build AddAgent')
     addagent = s.build_agents(AddAgent, 'addagent', 0)
-    s._prepare()
-    for r in range(rounds):
-        s.time(r)
-        for _ in range(5):
-            buy.do('one')
-            buy.do('two')
-            buy.do('three')
-            buy.do('clean_up')
-        buy.do('panel')
-        for _ in range(5):
-            sell.do('one')
-            sell.do('two')
-            sell.do('three')
-            sell.do('clean_up')
-        for _ in range(5):
-            give.do('one')
-            give.do('two')
-            give.do('three')
-            give.do('clean_up')
-        for _ in range(5):
-            loggertest.do('one')
-            loggertest.do('two')
-            loggertest.do('three')
-            loggertest.do('clean_up')
-        for _ in range(5):
-            utilityhousehold.do('one')
-            utilityhousehold.do('two')
-            utilityhousehold.do('three')
-            utilityhousehold.do('clean_up')
-        endowment.do('Iconsume')
-        productionmultifirm.do('production')
-        productionfirm.do('production')
-        utilityhousehold.do('consumption')
-        (messagea + messageb).do('sendmsg')
-        (messageb + messagea).do('recvmsg')
-        # (contractbuyer + contractbuyerstop).do('request_offer')
-        # (contractseller + contractsellerstop).do('make_offer')
-        # contractagents.do('accept_offer')
-        # contractagents.do('deliver')
-        # contractagents.do('pay')
-        # contractagents.do('control')
-        killer.do('kill')
-        killer.do('send_message')
-        victim.do('am_I_dead')
-        some.do('all_tests_completed')
-        addagent.do('add_agent')
-    s.gracefull_exit()
+    with s:
+        for r in range(rounds):
+            s.time(r)
+            for _ in range(5):
+                buy.do('one')
+                buy.do('two')
+                buy.do('three')
+                buy.do('clean_up')
+            buy.do('panel')
+            for _ in range(5):
+                sell.do('one')
+                sell.do('two')
+                sell.do('three')
+                sell.do('clean_up')
+            for _ in range(5):
+                give.do('one')
+                give.do('two')
+                give.do('three')
+                give.do('clean_up')
+            for _ in range(5):
+                loggertest.do('one')
+                loggertest.do('two')
+                loggertest.do('three')
+                loggertest.do('clean_up')
+            for _ in range(5):
+                utilityhousehold.do('one')
+                utilityhousehold.do('two')
+                utilityhousehold.do('three')
+                utilityhousehold.do('clean_up')
+            endowment.do('Iconsume')
+            productionmultifirm.do('production')
+            productionfirm.do('production')
+            utilityhousehold.do('consumption')
+            (messagea + messageb).do('sendmsg')
+            (messageb + messagea).do('recvmsg')
+            # (contractbuyer + contractbuyerstop).do('request_offer')
+            # (contractseller + contractsellerstop).do('make_offer')
+            # contractagents.do('accept_offer')
+            # contractagents.do('deliver')
+            # contractagents.do('pay')
+            # contractagents.do('control')
+            killer.do('kill')
+            killer.do('send_message')
+            victim.do('am_I_dead')
+            some.do('all_tests_completed')
+            addagent.do('add_agent')
 
 
 if __name__ == '__main__':

--- a/unittest/start_core_engine.py
+++ b/unittest/start_core_engine.py
@@ -90,9 +90,9 @@ def main(processes, rounds):
 
     print('build AddAgent')
     addagent = s.build_agents(AddAgent, 'addagent', 0)
-    with s:
+    with s.database:
         for r in range(rounds):
-            s.time(r)
+            s.advance_time(r)
             for _ in range(5):
                 buy.do('one')
                 buy.do('two')

--- a/unittest/start_logging_test.py
+++ b/unittest/start_logging_test.py
@@ -47,13 +47,12 @@ def main(processes):
 
     agents = simulation.build_agents(Agent, 'agent', 10, parameters='')
 
-    simulation._prepare()
-    for r in range(100):
-        simulation.time(r)
-        agents.do('go')
-        agents.aggregate()
-        agents.panel()
-    simulation.gracefull_exit()
+    with simulation:
+        for r in range(100):
+            simulation.time(r)
+            agents.do('go')
+            agents.aggregate()
+            agents.panel()
 
     if platform.system() == 'Windows':
         simulation.path = simulation.path.replace('/', '\\')

--- a/unittest/start_logging_test.py
+++ b/unittest/start_logging_test.py
@@ -40,17 +40,20 @@ def compare(to_compare, path, message):
 
 
 def main(processes):
-    simulation = abce.Simulation(rounds=100, processes=processes)
+    simulation = abce.Simulation(processes=processes)
 
     simulation.aggregate('agent', variables=['i', 'r'], possessions=['money'])
     simulation.panel('agent', variables=['i', 'r'], possessions=['money'])
 
     agents = simulation.build_agents(Agent, 'agent', 10, parameters='')
 
-    for r in simulation.next_round():
+    simulation._prepare()
+    for r in range(100):
+        simulation.time(r)
         agents.do('go')
         agents.aggregate()
         agents.panel()
+    simulation.gracefull_exit()
 
     if platform.system() == 'Windows':
         simulation.path = simulation.path.replace('/', '\\')

--- a/unittest/start_logging_test.py
+++ b/unittest/start_logging_test.py
@@ -23,15 +23,25 @@ def compare(to_compare, path, message):
         the_path = the_path[the_path.find('/') + 1:]
     really_is_full = pd.read_csv(the_path).sort_index(axis=1)
     if 'id' in should_be_full.columns:
-        should_be_full = should_be_full.sort_values(by=['id', 'round'], axis=0).reset_index(drop=True)
-        really_is_full = really_is_full.sort_values(by=['id', 'round'], axis=0).reset_index(drop=True)
+        should_be_full = (should_be_full
+                          .sort_values(by=['id', 'round'], axis=0)
+                          .reset_index(drop=True))
+        really_is_full = (really_is_full
+                          .sort_values(by=['id', 'round'], axis=0)
+                          .reset_index(drop=True))
         del should_be_full['index']
         del really_is_full['index']
     assert(should_be_full.shape == really_is_full.shape)
     if not np.isclose(should_be_full, really_is_full).all():
         # finds all lines which are different
-        should_be = should_be_full[np.logical_not(np.min(np.isclose(should_be_full, really_is_full), axis=1))]
-        really_is = really_is_full[np.logical_not(np.min(np.isclose(should_be_full, really_is_full), axis=1))]
+        should_be = should_be_full[np.logical_not(
+                                   np.min(np.isclose(should_be_full,
+                                                     really_is_full),
+                                          axis=1))]
+        really_is = really_is_full[np.logical_not(
+                                   np.min(np.isclose(should_be_full,
+                                                     really_is_full),
+                                          axis=1))]
 
         print(to_compare)
         raise Exception(pd.concat([should_be, really_is], axis=1))
@@ -47,24 +57,29 @@ def main(processes):
 
     agents = simulation.build_agents(Agent, 'agent', 10, parameters='')
 
-    with simulation.database:
-        for r in range(100):
-            simulation.advance_time(r)
-            agents.do('go')
-            agents.aggregate()
-            agents.panel()
+    for r in range(100):
+        simulation.advance_round(r)
+        agents.do('go')
+        agents.aggregate()
+        agents.panel()
+    simulation.finalize()
 
     if platform.system() == 'Windows':
         simulation.path = simulation.path.replace('/', '\\')
 
-    compare('aggregate_agent.csv', simulation.path, 'aggregate logging test\t\t')
-    compare('aggregate_agent_mean.csv', simulation.path, 'aggregate logging test mean\t')
-    compare('aggregate_agent_std.csv', simulation.path, 'aggregate logging test std\t')
+    compare('aggregate_agent.csv',
+            simulation.path, 'aggregate logging test\t\t')
+    compare('aggregate_agent_mean.csv',
+            simulation.path, 'aggregate logging test mean\t')
+    compare('aggregate_agent_std.csv',
+            simulation.path, 'aggregate logging test std\t')
 
-    compare('aggregate_log_agent.csv', simulation.path, 'self.log test \t\t\t')
+    compare('aggregate_log_agent.csv',
+            simulation.path, 'self.log test \t\t\t')
     compare('log_agent.csv', simulation.path, 'self.log test\t\t\t\t')
 
-    compare('aggregate_panel_agent.csv', simulation.path, 'aggregated panel logging test\t')
+    compare('aggregate_panel_agent.csv',
+            simulation.path, 'aggregated panel logging test\t')
     compare('panel_agent.csv', simulation.path, 'panel logging test\t\t\t')
 
 

--- a/unittest/start_logging_test.py
+++ b/unittest/start_logging_test.py
@@ -47,9 +47,9 @@ def main(processes):
 
     agents = simulation.build_agents(Agent, 'agent', 10, parameters='')
 
-    with simulation:
+    with simulation.database:
         for r in range(100):
-            simulation.time(r)
+            simulation.advance_time(r)
             agents.do('go')
             agents.aggregate()
             agents.panel()


### PR DESCRIPTION
Cleaned and reviewed version of #51.

A round is now executed this way:

```
simulation = abce.Simulation(processes=processes)

simulation.aggregate('agent', variables=['i', 'r'], possessions=['money'])
simulation.panel('agent', variables=['i', 'r'], possessions=['money'])

agents = simulation.build_agents(Agent, 'agent', 10, parameters='')

for r in range(100):
    simulation.advance_round(r)
    agents.do('go')
    agents.aggregate()
    agents.panel()
simulation.finalize()
```

With this, custom scheduler can be more easily plugged in, rather than too soldered-in in `next_round`.