### PR TITLE
Fix readthedocs.io link on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Install with::
 
 The documentation is here:
 
-    http://abcEconomics.readthedocs.io/
+    http://abce.readthedocs.io/
 
 An example is here:
 


### PR DESCRIPTION
Hi,

Just passing through and noticed that the readthedocs link looks to be out of date. I put what I presume is the correct link.

Thanks,
Nikolaj